### PR TITLE
Fix Khepri calls for clustering refactors

### DIFF
--- a/src/khepri_benchmark_khepri.erl
+++ b/src/khepri_benchmark_khepri.erl
@@ -169,7 +169,7 @@ stop_khepri(Nodes) ->
     ok.
 
 remove_khepri_dir(Nodes) ->
-    _ = [file:del_dir_r(io_lib:format("~s", [Node])) || Node <- Nodes],
+    _ = [file:del_dir_r(io_lib:format("khepri#~s", [Node])) || Node <- Nodes],
     ok.
 
 insert_in_khepri() ->

--- a/src/khepri_benchmark_khepri.erl
+++ b/src/khepri_benchmark_khepri.erl
@@ -130,8 +130,10 @@ setup_khepri(Nodes, Profile) ->
          end || Node <- Nodes],
 
     {ok, _} = khepri:start(),
-    _ = [ok = khepri_cluster:add_member(?RA_SYSTEM, Node)
-         || Node <- Nodes, Node =/= node()],
+    _ = [begin
+             {ok, _} = rpc:call(Node, khepri, start, []),
+             ok = rpc:call(Node, khepri_cluster, join, [node()])
+         end || Node <- Nodes, Node =/= node()],
 
     _ = [begin
              Members = [Member


### PR DESCRIPTION
rabbitmq/khepri#105 made a few changes that affect how the benchmark code here should work:

* `khepri#$NODENAME` is the new default data directory instead of just `$NODENAME`
* `khepri:add_member/2` has been replaced with `khepri_cluster:join/1` (also `khepri:start/0` must be called first on the joining node)